### PR TITLE
Implement audio samples slicing for realtime transcription

### DIFF
--- a/android/src/main/java/com/rnwhisper/WhisperContext.java
+++ b/android/src/main/java/com/rnwhisper/WhisperContext.java
@@ -260,11 +260,12 @@ public class WhisperContext {
       transcribeSliceIndex != sliceIndex
     ) {
       transcribeSliceIndex++;
+      nSamplesTranscribing = 0;
+    }
 
-      if (!isCapturing) {
-        // If no more capturing, continue transcribing until all slices are transcribed
-        fullTranscribeSamples(options, true);
-      }
+    if (!isCapturing && nSamplesTranscribing != nSamplesOfIndex) {
+      // If no more capturing, continue transcribing until all slices are transcribed
+      fullTranscribeSamples(options, true);
     }
     isTranscribing = false;
   }

--- a/android/src/main/java/com/rnwhisper/WhisperContext.java
+++ b/android/src/main/java/com/rnwhisper/WhisperContext.java
@@ -60,7 +60,6 @@ public class WhisperContext {
   private boolean isCapturing = false;
   private boolean isStoppedByAction = false;
   private boolean isTranscribing = false;
-  private boolean isFirstTranscribing = true;
   private Thread fullHandler = null;
 
   public WhisperContext(int id, ReactApplicationContext reactContext, long context) {
@@ -81,7 +80,6 @@ public class WhisperContext {
     isCapturing = false;
     isStoppedByAction = false;
     isTranscribing = false;
-    isFirstTranscribing = true;
     fullHandler = null;
   }
 
@@ -255,7 +253,6 @@ public class WhisperContext {
       payload.putBoolean("isCapturing", true);
       emitTranscribeEvent("@RNWhisper_onRealtimeTranscribe", payload);
     }
-    isFirstTranscribing = false;
 
     if (
       // If no more samples on current slice, move to next slice
@@ -297,10 +294,6 @@ public class WhisperContext {
     return fullTranscribe(
       jobId,
       context,
-      // jboolean no_context,
-      !isRealtime || !isUseSlices || isFirstTranscribing,
-      // jboolean realtime,
-      isRealtime,
       // float[] audio_data,
       audioData,
       // jint audio_data_len,
@@ -478,8 +471,6 @@ public class WhisperContext {
   protected static native int fullTranscribe(
     int job_id,
     long context,
-    boolean no_context,
-    boolean realtime,
     float[] audio_data,
     int audio_data_len,
     int n_threads,

--- a/android/src/main/java/com/rnwhisper/WhisperContext.java
+++ b/android/src/main/java/com/rnwhisper/WhisperContext.java
@@ -170,6 +170,8 @@ public class WhisperContext {
           if (fullHandler != null) {
             fullHandler.join(); // Wait for full transcribe to finish
           }
+          // Cleanup
+          shortBufferSlices.clear();
           recorder.stop();
         } catch (Exception e) {
           e.printStackTrace();

--- a/android/src/main/java/com/rnwhisper/WhisperContext.java
+++ b/android/src/main/java/com/rnwhisper/WhisperContext.java
@@ -238,10 +238,11 @@ public class WhisperContext {
       payload.putString("error", "Transcribe failed with code " + code);
     }
 
+    nSamplesOfIndex = sliceNSamples.get(transcribeSliceIndex);
     if (
       isStoppedByAction ||
       !isCapturing &&
-      nSamplesTranscribing == nSamples &&
+      nSamplesTranscribing == nSamplesOfIndex &&
       sliceIndex == transcribeSliceIndex
     ) {
       payload.putBoolean("isCapturing", false);
@@ -297,7 +298,7 @@ public class WhisperContext {
       jobId,
       context,
       // jboolean no_context,
-      !isUseSlices || isFirstTranscribing,
+      !isRealtime || !isUseSlices || isFirstTranscribing,
       // jboolean realtime,
       isRealtime,
       // float[] audio_data,

--- a/android/src/main/jni/whisper/jni.cpp
+++ b/android/src/main/jni/whisper/jni.cpp
@@ -39,8 +39,6 @@ Java_com_rnwhisper_WhisperContext_fullTranscribe(
     jobject thiz,
     jint job_id,
     jlong context_ptr,
-    jboolean no_context,
-    jboolean realtime,
     jfloatArray audio_data,
     jint audio_data_len,
     jint n_threads,
@@ -84,8 +82,8 @@ Java_com_rnwhisper_WhisperContext_fullTranscribe(
     params.n_threads = n_threads > 0 ? n_threads : max_threads;
     params.speed_up = speed_up;
     params.offset_ms = 0;
-    params.no_context = no_context;
-    params.single_segment = realtime;
+    params.no_context = true;
+    params.single_segment = false;
 
     if (max_len > -1) {
         params.max_len = max_len;

--- a/android/src/main/jni/whisper/jni.cpp
+++ b/android/src/main/jni/whisper/jni.cpp
@@ -39,6 +39,7 @@ Java_com_rnwhisper_WhisperContext_fullTranscribe(
     jobject thiz,
     jint job_id,
     jlong context_ptr,
+    jboolean no_context,
     jboolean realtime,
     jfloatArray audio_data,
     jint audio_data_len,
@@ -83,7 +84,7 @@ Java_com_rnwhisper_WhisperContext_fullTranscribe(
     params.n_threads = n_threads > 0 ? n_threads : max_threads;
     params.speed_up = speed_up;
     params.offset_ms = 0;
-    params.no_context = true;
+    params.no_context = no_context;
     params.single_segment = realtime;
 
     if (max_len > -1) {

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -226,8 +226,10 @@ export default function App() {
                 const { stop, subscribe } =
                   await whisperContext.transcribeRealtime({
                     language: 'en',
-                    realtimeAudioSec: 12,
-                    realtimeSliceInterval: 5,
+                    // Record duration in seconds
+                    realtimeAudioSec: 60,
+                    // Slice audio into 25 (or < 30) sec chunks for better performance
+                    realtimeAudioSliceSec: 25,
                   })
                 setStopTranscribe({ stop })
                 subscribe((evt) => {

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -226,7 +226,8 @@ export default function App() {
                 const { stop, subscribe } =
                   await whisperContext.transcribeRealtime({
                     language: 'en',
-                    realtimeAudioSec: 10,
+                    realtimeAudioSec: 12,
+                    realtimeSliceInterval: 5,
                   })
                 setStopTranscribe({ stop })
                 subscribe((evt) => {
@@ -235,7 +236,17 @@ export default function App() {
                     `Realtime transcribing: ${isCapturing ? 'ON' : 'OFF'}\n` +
                       `Result: ${data.result}\n\n` +
                       `Process time: ${processTime}ms\n` +
-                      `Recording time: ${recordingTime}ms`,
+                      `Recording time: ${recordingTime}ms` +
+                      `\n` +
+                      `Segments:` +
+                      `\n${data.segments
+                        .map(
+                          (segment) =>
+                            `[${toTimestamp(segment.t0)} --> ${toTimestamp(
+                              segment.t1,
+                            )}]  ${segment.text}`,
+                        )
+                        .join('\n')}`,
                   )
                   if (!isCapturing) {
                     setStopTranscribe(null)

--- a/ios/RNWhisperContext.h
+++ b/ios/RNWhisperContext.h
@@ -27,6 +27,7 @@ typedef struct {
     int sliceIndex;
     int transcribeSliceIndex;
     int audioSliceSec;
+    bool isFirstTranscribing;
 
     AudioQueueRef queue;
     AudioStreamBasicDescription dataFormat;

--- a/ios/RNWhisperContext.h
+++ b/ios/RNWhisperContext.h
@@ -27,7 +27,6 @@ typedef struct {
     int sliceIndex;
     int transcribeSliceIndex;
     int audioSliceSec;
-    bool isFirstTranscribing;
 
     AudioQueueRef queue;
     AudioStreamBasicDescription dataFormat;

--- a/ios/RNWhisperContext.h
+++ b/ios/RNWhisperContext.h
@@ -20,10 +20,13 @@ typedef struct {
     bool isCapturing;
     bool isStoppedByAction;
     int maxAudioSec;
-    int nSamples;
     int nSamplesTranscribing;
-    int16_t* audioBufferI16;
-    float* audioBufferF32;
+    NSMutableArray<NSValue *> *shortBufferSlices;
+    NSMutableArray<NSNumber *> *sliceNSamples;
+    bool isUseSlices;
+    int sliceIndex;
+    int transcribeSliceIndex;
+    int audioSliceSec;
 
     AudioQueueRef queue;
     AudioStreamBasicDescription dataFormat;

--- a/ios/RNWhisperContext.mm
+++ b/ios/RNWhisperContext.mm
@@ -40,7 +40,6 @@
     self->recordState.sliceIndex = 0;
     self->recordState.transcribeSliceIndex = 0;
     self->recordState.nSamplesTranscribing = 0;
-    self->recordState.isFirstTranscribing = true;
 
     [self freeBufferIfNeeded];
     self->recordState.shortBufferSlices = [NSMutableArray new];
@@ -201,8 +200,6 @@ void AudioInputCallback(void * inUserData,
         state->transcribeHandler(state->jobId, @"transcribe", result);
     }
 
-    state->isFirstTranscribing = false;
-
     if (
       // If no more samples on current slice, move to next slice
       state->nSamplesTranscribing == nSamplesOfIndex &&
@@ -321,10 +318,8 @@ void AudioInputCallback(void * inUserData,
     params.language         = options[@"language"] != nil ? [options[@"language"] UTF8String] : "auto";
     params.n_threads        = max_threads;
     params.offset_ms        = 0;
-    params.no_context       = !self->recordState.isRealtime ||
-        !self->recordState.isUseSlices ||
-        self->recordState.isFirstTranscribing;
-    params.single_segment   = self->recordState.isRealtime;
+    params.no_context       = true;
+    params.single_segment   = false;
 
     if (options[@"maxLen"] != nil) {
         params.max_len = [options[@"maxLen"] intValue];
@@ -395,6 +390,7 @@ void AudioInputCallback(void * inUserData,
             @"t0": [NSNumber numberWithLongLong:t0],
             @"t1": [NSNumber numberWithLongLong:t1]
         };
+        NSLog(@"segment: %@", segment);
         [segments addObject:segment];
     }
     return @{

--- a/ios/RNWhisperContext.mm
+++ b/ios/RNWhisperContext.mm
@@ -90,7 +90,6 @@ void AudioInputCallback(void * inUserData,
     }
 
     const int n = inBuffer->mAudioDataByteSize / 2;
-    NSLog(@"[RNWhisper] Captured %d new samples", n);
 
     int nSamples = [state->sliceNSamples[state->sliceIndex] intValue];
 
@@ -134,7 +133,7 @@ void AudioInputCallback(void * inUserData,
         audioBufferI16[nSamples + i] = ((short*)inBuffer->mAudioData)[i];
     }
     nSamples += n;
-    [state->sliceNSamples replaceObjectAtIndex:state->sliceIndex withObject:[NSNumber numberWithInt:nSamples]];
+    state->sliceNSamples[state->sliceIndex] = [NSNumber numberWithInt:nSamples];
 
     AudioQueueEnqueueBuffer(state->queue, inBuffer, 0, NULL);
 
@@ -390,7 +389,6 @@ void AudioInputCallback(void * inUserData,
             @"t0": [NSNumber numberWithLongLong:t0],
             @"t1": [NSNumber numberWithLongLong:t1]
         };
-        NSLog(@"segment: %@", segment);
         [segments addObject:segment];
     }
     return @{

--- a/ios/RNWhisperContext.mm
+++ b/ios/RNWhisperContext.mm
@@ -40,6 +40,7 @@
     self->recordState.sliceIndex = 0;
     self->recordState.transcribeSliceIndex = 0;
     self->recordState.nSamplesTranscribing = 0;
+    self->recordState.isFirstTranscribing = true;
 
     [self freeBufferIfNeeded];
     self->recordState.shortBufferSlices = [NSMutableArray new];
@@ -200,6 +201,8 @@ void AudioInputCallback(void * inUserData,
         state->transcribeHandler(state->jobId, @"transcribe", result);
     }
 
+    state->isFirstTranscribing = false;
+
     if (
       // If no more samples on current slice, move to next slice
       state->nSamplesTranscribing == nSamplesOfIndex &&
@@ -318,7 +321,9 @@ void AudioInputCallback(void * inUserData,
     params.language         = options[@"language"] != nil ? [options[@"language"] UTF8String] : "auto";
     params.n_threads        = max_threads;
     params.offset_ms        = 0;
-    params.no_context       = true;
+    params.no_context       = !self->recordState.isRealtime ||
+        !self->recordState.isUseSlices ||
+        self->recordState.isFirstTranscribing;
     params.single_segment   = self->recordState.isRealtime;
 
     if (options[@"maxLen"] != nil) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -108,21 +108,23 @@ export type TranscribeRealtimeEvent = {
   }>,
 }
 
+export type TranscribeRealtimeNativePayload = {
+  /** Is capturing audio, when false, the event is the final result */
+  isCapturing: boolean,
+  isStoppedByAction?: boolean,
+  code: number,
+  processTime: number,
+  recordingTime: number,
+  isUseSlices: boolean,
+  sliceIndex: number,
+  data?: TranscribeResult,
+  error?: string,
+}
+
 export type TranscribeRealtimeNativeEvent = {
   contextId: number,
   jobId: number,
-  payload: {
-    /** Is capturing audio, when false, the event is the final result */
-    isCapturing: boolean,
-    isStoppedByAction?: boolean,
-    code: number,
-    processTime: number,
-    recordingTime: number,
-    isUseSlices: boolean,
-    sliceIndex: number,
-    data?: TranscribeResult,
-    error?: string,
-  },
+  payload: TranscribeRealtimeNativePayload,
 }
 
 class WhisperContext {
@@ -155,13 +157,13 @@ class WhisperContext {
   }> {
     const jobId: number = Math.floor(Math.random() * 10000)
     await RNWhisper.startRealtimeTranscribe(this.id, jobId, options)
-    let lastTranscribePayload: TranscribeRealtimeNativeEvent['payload']
+    let lastTranscribePayload: TranscribeRealtimeNativePayload
 
-    const slices: TranscribeRealtimeNativeEvent['payload'][] = []
+    const slices: TranscribeRealtimeNativePayload[] = []
     let sliceIndex: number = 0
     let tOffset: number = 0
 
-    const putSlice = (payload: TranscribeRealtimeNativeEvent['payload']) => {
+    const putSlice = (payload: TranscribeRealtimeNativePayload) => {
       if (!payload.isUseSlices) return
       if (sliceIndex !== payload.sliceIndex) {
         const { segments = [] } = slices[sliceIndex]?.data || {}
@@ -181,7 +183,7 @@ class WhisperContext {
       }
     }
 
-    const mergeSlicesIfNeeded = (payload: TranscribeRealtimeNativeEvent['payload']): TranscribeRealtimeNativeEvent['payload'] => {
+    const mergeSlicesIfNeeded = (payload: TranscribeRealtimeNativePayload): TranscribeRealtimeNativePayload => {
       if (!payload.isUseSlices) return payload
 
       const mergedPayload: any = {}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -71,6 +71,12 @@ export type TranscribeRealtimeOptions = TranscribeOptions & {
    * the recommended value will be <= 30 seconds. (Default: 30)
    */
   realtimeAudioSec?: number,
+  /**
+   * Optimize audio transcription performance by slicing audio samples when `realtimeAudioSec` > 30.
+   * Set `realtimeAudioSliceSec` < 30 so performance improvements can be achieved in the Whisper hard constraint (processes the audio in chunks of 30 seconds).
+   * (Default: Equal to `realtimeMaxAudioSec`)
+   */
+  realtimeAudioSliceSec?: number
 }
 
 export type TranscribeResult = {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -165,7 +165,7 @@ class WhisperContext {
       if (!payload.isUseSlices) return
       if (sliceIndex !== payload.sliceIndex) {
         const { segments = [] } = slices[sliceIndex]?.data || {}
-        tOffset += segments[segments.length - 1]?.t1 || 0
+        tOffset = segments[segments.length - 1]?.t1 || 0
       }
       ({ sliceIndex } = payload)
       slices[sliceIndex] = {


### PR DESCRIPTION
Provide option: `realtimeAudioSliceSec` (default: equal `realtimeAudioSec`).

For better performace if realtimeAudioSec > 30. Set sliceInterval < 30 so performance improvements can be achieved in the whisper model hard constraint (processes the audio in chunks of 30 seconds).

However, it may also cause word breaks, so I'm planning to do the pitch detection in the future.

- [x] Android
- [x] JS: return `slices` in `TranscribeResult`
- [x] iOS
~~- [ ] This option may need to set `no_context` to false to improve the accuracy.~~
