### PR TITLE
Finish the transcription for last audio samples

### DIFF
--- a/android/src/main/java/com/rnwhisper/WhisperContext.java
+++ b/android/src/main/java/com/rnwhisper/WhisperContext.java
@@ -126,6 +126,9 @@ public class WhisperContext {
               Log.e(NAME, "Error transcribing realtime: " + e.getMessage());
             }
           }
+          if (!isTranscribing) {
+            emitTranscribeEvent("@RNWhisper_onRealtimeTranscribeEnd", Arguments.createMap());
+          }
           if (fullHandler != null) {
             fullHandler.join(); // Wait for full transcribe to finish
           }

--- a/android/src/main/java/com/rnwhisper/WhisperContext.java
+++ b/android/src/main/java/com/rnwhisper/WhisperContext.java
@@ -169,17 +169,21 @@ public class WhisperContext {
           payload.putInt("processTime", timeEnd - timeStart);
           payload.putInt("recordingTime", timeRecording);
 
+          if (code == 0) {
+            payload.putMap("data", getTextSegments());
+          } else {
+            payload.putString("error", "Transcribe failed with code " + code);
+          }
+
           if (isStoppedByAction || !isCapturing && nSamplesTranscribing == nSamples) {
             payload.putBoolean("isCapturing", false);
             payload.putBoolean("isStoppedByAction", isStoppedByAction);
             emitTranscribeEvent("@RNWhisper_onRealtimeTranscribeEnd", payload);
           } else if (code == 0) {
             payload.putBoolean("isCapturing", true);
-            payload.putMap("data", getTextSegments());
             emitTranscribeEvent("@RNWhisper_onRealtimeTranscribe", payload);
           } else {
             payload.putBoolean("isCapturing", true);
-            payload.putString("error", "Transcribe failed with code " + code);
             emitTranscribeEvent("@RNWhisper_onRealtimeTranscribe", payload);
           }
           isTranscribing = false;

--- a/ios/RNWhisperContext.h
+++ b/ios/RNWhisperContext.h
@@ -18,8 +18,10 @@ typedef struct {
     bool isTranscribing;
     bool isRealtime;
     bool isCapturing;
+    bool isStoppedByAction;
     int maxAudioSec;
     int nSamples;
+    int nSamplesTranscribing;
     int16_t* audioBufferI16;
     float* audioBufferF32;
 


### PR DESCRIPTION
Currently the `transcribeRealtime` method can record the audio samples at the set time, but the transcription doesn't continue after the recording stops, this results in some audio samples not being used, especially on devices with poor performance.

We can continue the transcription if the audio stopped capturing, then send the end event.

- [x] Android
- [x] iOS