### PR TITLE
feat(android): always use optimizations on debug mode

### DIFF
--- a/android/src/main/jni/whisper/Whisper.mk
+++ b/android/src/main/jni/whisper/Whisper.mk
@@ -1,15 +1,18 @@
 WHISPER_LIB_DIR := $(LOCAL_PATH)/../../../../../cpp
 LOCAL_LDLIBS    := -landroid -llog
 
+# NOTE: If you want to debug the native code, you can uncomment ifneq and endif
+# ifneq ($(APP_OPTIM),debug)
+
 # Make the final output library smaller by only keeping the symbols referenced from the app.
-ifneq ($(APP_OPTIM),debug)
-    LOCAL_CFLAGS += -O3 -DNDEBUG
-    LOCAL_CFLAGS += -fvisibility=hidden -fvisibility-inlines-hidden
-    LOCAL_CFLAGS += -ffunction-sections -fdata-sections
-    LOCAL_LDFLAGS += -Wl,--gc-sections
-    LOCAL_LDFLAGS += -Wl,--exclude-libs,ALL
-    LOCAL_LDFLAGS += -flto
-endif
+LOCAL_CFLAGS += -O3 -DNDEBUG
+LOCAL_CFLAGS += -fvisibility=hidden -fvisibility-inlines-hidden
+LOCAL_CFLAGS += -ffunction-sections -fdata-sections
+LOCAL_LDFLAGS += -Wl,--gc-sections
+LOCAL_LDFLAGS += -Wl,--exclude-libs,ALL
+LOCAL_LDFLAGS += -flto
+
+# endif
 
 LOCAL_CFLAGS    += -DSTDC_HEADERS -std=c11 -I $(WHISPER_LIB_DIR)
 LOCAL_CPPFLAGS  += -std=c++11 -I $(WHISPER_LIB_DIR)


### PR DESCRIPTION
In most cases we don't need too much debug details when using whisper.rn, so the optimizations can be always on, we can turn it off when we have problems on native code.

This allows users to focus more on developing RN apps.