### PR TITLE
fix: add prefix to avoid redef with other libraries using ggml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
           cd example
           xcodebuild -workspace ios/RNWhisperExample.xcworkspace -scheme RNWhisperExample -configuration Debug -sdk iphonesimulator -derivedDataPath ios/build
   test-android:
-    runs-on: macOS-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3.7.0

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -759,7 +759,7 @@ PODS:
     - SSZipArchive (~> 2.2)
   - SocketRocket (0.6.0)
   - SSZipArchive (2.4.3)
-  - whisper-rn (0.3.1):
+  - whisper-rn (0.3.2):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
@@ -997,7 +997,7 @@ SPEC CHECKSUMS:
   RNZipArchive: 68a0c6db4b1c103f846f1559622050df254a3ade
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
   SSZipArchive: fe6a26b2a54d5a0890f2567b5cc6de5caa600aef
-  whisper-rn: 016f6f83991e8cc742af108cdb6494f410d0a627
+  whisper-rn: 30bc8047fd30ec3f8d38de48fd656453cd0d30d0
   Yoga: f7decafdc5e8c125e6fa0da38a687e35238420fa
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -8,6 +8,8 @@ cp ./whisper.cpp/ggml.c ./cpp/ggml.c
 cp ./whisper.cpp/whisper.h ./cpp/whisper.h
 cp ./whisper.cpp/whisper.cpp ./cpp/whisper.cpp
 
+cp -R ./whisper.cpp/coreml/ ./cpp/coreml/
+
 # Add prefix to avoid redefinition with other libraries using ggml like llama.rn
 sed -i '' 's/GGML_/WSP_GGML_/g' ./cpp/ggml.h
 sed -i '' 's/ggml_/wsp_ggml_/g' ./cpp/ggml.h
@@ -18,7 +20,28 @@ sed -i '' 's/ggml_/wsp_ggml_/g' ./cpp/whisper.h
 sed -i '' 's/GGML_/WSP_GGML_/g' ./cpp/whisper.cpp
 sed -i '' 's/ggml_/wsp_ggml_/g' ./cpp/whisper.cpp
 
-cp -R ./whisper.cpp/coreml/ ./cpp/coreml/
+# List of files to process
+files=(
+  "./cpp/ggml.h"
+  "./cpp/ggml.c"
+  "./cpp/whisper.h"
+  "./cpp/whisper.cpp"
+)
+
+# Loop through each file and run the sed commands
+OS=$(uname)
+for file in "${files[@]}"; do
+  # Add prefix to avoid redefinition with other libraries using ggml like whisper.rn
+  if [ "$OS" = "Darwin" ]; then
+    sed -i '' 's/GGML_/LM_GGML_/g' $file
+    sed -i '' 's/ggml_/lm_ggml_/g' $file
+  else
+    sed -i 's/GGML_/LM_GGML_/g' $file
+    sed -i 's/ggml_/lm_ggml_/g' $file
+  fi
+done
+
+echo "Replacement completed successfully!"
 
 # Parse whisper.cpp/bindings/javascript/package.json version and set to src/version.json
 cd whisper.cpp/bindings/javascript

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -7,6 +7,17 @@ cp ./whisper.cpp/ggml.h ./cpp/ggml.h
 cp ./whisper.cpp/ggml.c ./cpp/ggml.c
 cp ./whisper.cpp/whisper.h ./cpp/whisper.h
 cp ./whisper.cpp/whisper.cpp ./cpp/whisper.cpp
+
+# Add prefix to avoid redefinition with other libraries using ggml like llama.rn
+sed -i '' 's/GGML_/WSP_GGML_/g' ./cpp/ggml.h
+sed -i '' 's/ggml_/wsp_ggml_/g' ./cpp/ggml.h
+sed -i '' 's/GGML_/WSP_GGML_/g' ./cpp/ggml.c
+sed -i '' 's/ggml_/wsp_ggml_/g' ./cpp/ggml.c
+sed -i '' 's/GGML_/WSP_GGML_/g' ./cpp/whisper.h
+sed -i '' 's/ggml_/wsp_ggml_/g' ./cpp/whisper.h
+sed -i '' 's/GGML_/WSP_GGML_/g' ./cpp/whisper.cpp
+sed -i '' 's/ggml_/wsp_ggml_/g' ./cpp/whisper.cpp
+
 cp -R ./whisper.cpp/coreml/ ./cpp/coreml/
 
 # Parse whisper.cpp/bindings/javascript/package.json version and set to src/version.json

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -10,16 +10,6 @@ cp ./whisper.cpp/whisper.cpp ./cpp/whisper.cpp
 
 cp -R ./whisper.cpp/coreml/ ./cpp/coreml/
 
-# Add prefix to avoid redefinition with other libraries using ggml like llama.rn
-sed -i '' 's/GGML_/WSP_GGML_/g' ./cpp/ggml.h
-sed -i '' 's/ggml_/wsp_ggml_/g' ./cpp/ggml.h
-sed -i '' 's/GGML_/WSP_GGML_/g' ./cpp/ggml.c
-sed -i '' 's/ggml_/wsp_ggml_/g' ./cpp/ggml.c
-sed -i '' 's/GGML_/WSP_GGML_/g' ./cpp/whisper.h
-sed -i '' 's/ggml_/wsp_ggml_/g' ./cpp/whisper.h
-sed -i '' 's/GGML_/WSP_GGML_/g' ./cpp/whisper.cpp
-sed -i '' 's/ggml_/wsp_ggml_/g' ./cpp/whisper.cpp
-
 # List of files to process
 files=(
   "./cpp/ggml.h"
@@ -31,13 +21,13 @@ files=(
 # Loop through each file and run the sed commands
 OS=$(uname)
 for file in "${files[@]}"; do
-  # Add prefix to avoid redefinition with other libraries using ggml like whisper.rn
+  # Add prefix to avoid redefinition with other libraries using ggml like llama.rn
   if [ "$OS" = "Darwin" ]; then
-    sed -i '' 's/GGML_/LM_GGML_/g' $file
-    sed -i '' 's/ggml_/lm_ggml_/g' $file
+    sed -i '' 's/GGML_/WSP_GGML_/g' $file
+    sed -i '' 's/ggml_/wsp_ggml_/g' $file
   else
-    sed -i 's/GGML_/LM_GGML_/g' $file
-    sed -i 's/ggml_/lm_ggml_/g' $file
+    sed -i 's/GGML_/WSP_GGML_/g' $file
+    sed -i 's/ggml_/wsp_ggml_/g' $file
   fi
 done
 

--- a/whisper-rn.podspec
+++ b/whisper-rn.podspec
@@ -2,7 +2,7 @@ require "json"
 
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 base_ld_flags = "-framework Accelerate"
-base_compiler_flags = "-DGGML_USE_ACCELERATE -Wno-shorten-64-to-32"
+base_compiler_flags = "-DWSP_GGML_USE_ACCELERATE -Wno-shorten-64-to-32"
 folly_compiler_flags = "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma"
 
 # Use base_optimizer_flags = "" for debug builds


### PR DESCRIPTION
Currently the ggml functions will affected other libraries using a diff version of ggml in an iOS project, such as [llama.rn](https://github.com/mybigday/llama.rn) which we're experimenting with. This change just add a prefix to types / function by script to avoid redefinition issue.