### PR TITLE
fix: wait queue/task finished on stopTranscribe

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -759,7 +759,7 @@ PODS:
     - SSZipArchive (~> 2.2)
   - SocketRocket (0.6.0)
   - SSZipArchive (2.4.3)
-  - whisper-rn (0.3.4):
+  - whisper-rn (0.3.5):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
@@ -997,7 +997,7 @@ SPEC CHECKSUMS:
   RNZipArchive: 68a0c6db4b1c103f846f1559622050df254a3ade
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
   SSZipArchive: fe6a26b2a54d5a0890f2567b5cc6de5caa600aef
-  whisper-rn: a24af0dd79eb6dc1ebacbb110a7120fad0d64818
+  whisper-rn: 6f293154b175fee138a994fa00d0f414fb1f44e9
   Yoga: f7decafdc5e8c125e6fa0da38a687e35238420fa
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -250,7 +250,10 @@ export default function App() {
             onPress={async () => {
               if (!whisperContext) return log('No context')
               if (stopTranscribe?.stop) {
-                stopTranscribe?.stop()
+                const t0 = Date.now()
+                await stopTranscribe?.stop()
+                const t1 = Date.now()
+                log('Stopped transcribing in', t1 - t0, 'ms')
                 setStopTranscribe(null)
                 return
               }

--- a/ios/RNWhisper.mm
+++ b/ios/RNWhisper.mm
@@ -68,13 +68,17 @@ RCT_REMAP_METHOD(initContext,
         path = [[NSBundle mainBundle] pathForResource:modelPath ofType:nil];
     }
 
-    RNWhisperContext *context = [RNWhisperContext initWithModelPath:path];
+    int contextId = arc4random_uniform(1000000);
+
+    RNWhisperContext *context = [RNWhisperContext
+        initWithModelPath:path
+        contextId:contextId
+    ];
     if ([context getContext] == NULL) {
         reject(@"whisper_cpp_error", @"Failed to load the model", nil);
         return;
     }
 
-    int contextId = arc4random_uniform(1000000);
     [contexts setObject:context forKey:[NSNumber numberWithInt:contextId]];
 
     resolve([NSNumber numberWithInt:contextId]);

--- a/ios/RNWhisper.mm
+++ b/ios/RNWhisper.mm
@@ -122,36 +122,36 @@ RCT_REMAP_METHOD(transcribeFile,
         reject(@"whisper_error", @"Invalid file", nil);
         return;
     }
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        int code = [context transcribeFile:jobId
-            audioData:waveFile
-            audioDataCount:count
-            options:options
-            onProgress: ^(int progress) {
-                if (rn_whisper_transcribe_is_aborted(jobId)) {
-                    return;
-                }
-                dispatch_async(dispatch_get_main_queue(), ^{
-                    [self sendEventWithName:@"@RNWhisper_onTranscribeProgress"
-                        body:@{
-                            @"contextId": [NSNumber numberWithInt:contextId],
-                            @"jobId": [NSNumber numberWithInt:jobId],
-                            @"progress": [NSNumber numberWithInt:progress]
-                        }
-                    ];
-                });
+    [context transcribeFile:jobId
+        audioData:waveFile
+        audioDataCount:count
+        options:options
+        onProgress: ^(int progress) {
+            if (rn_whisper_transcribe_is_aborted(jobId)) {
+                return;
             }
-        ];
-        if (code != 0) {
-            free(waveFile);
-            reject(@"whisper_cpp_error", [NSString stringWithFormat:@"Failed to transcribe the file. Code: %d", code], nil);
-            return;
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [self sendEventWithName:@"@RNWhisper_onTranscribeProgress"
+                    body:@{
+                        @"contextId": [NSNumber numberWithInt:contextId],
+                        @"jobId": [NSNumber numberWithInt:jobId],
+                        @"progress": [NSNumber numberWithInt:progress]
+                    }
+                ];
+            });
         }
-        free(waveFile);
-        NSMutableDictionary *result = [context getTextSegments];
-        result[@"isAborted"] = @([context isStoppedByAction]);
-        resolve(result);
-    });
+        onEnd: ^(int code) {
+            if (code != 0) {
+                free(waveFile);
+                reject(@"whisper_cpp_error", [NSString stringWithFormat:@"Failed to transcribe the file. Code: %d", code], nil);
+                return;
+            }
+            free(waveFile);
+            NSMutableDictionary *result = [context getTextSegments];
+            result[@"isAborted"] = @([context isStoppedByAction]);
+            resolve(result);
+        }
+    ];
 }
 
 RCT_REMAP_METHOD(startRealtimeTranscribe,

--- a/ios/RNWhisper.mm
+++ b/ios/RNWhisper.mm
@@ -264,7 +264,7 @@ RCT_REMAP_METHOD(releaseAllContexts,
 }
 
 - (void)invalidate {
-    rn_whisper_abort_all_transcribe();
+    [super invalidate];
 
     if (contexts == nil) {
         return;
@@ -274,6 +274,8 @@ RCT_REMAP_METHOD(releaseAllContexts,
         RNWhisperContext *context = contexts[contextId];
         [context invalidate];
     }
+
+    rn_whisper_abort_all_transcribe(); // graceful abort
 
     [contexts removeAllObjects];
     contexts = nil;

--- a/ios/RNWhisperContext.h
+++ b/ios/RNWhisperContext.h
@@ -55,6 +55,7 @@ typedef struct {
     onProgress:(void (^)(int))onProgress
     onEnd:(void (^)(int))onEnd;
 - (void)stopTranscribe:(int)jobId;
+- (void)stopCurrentTranscribe;
 - (bool)isCapturing;
 - (bool)isTranscribing;
 - (bool)isStoppedByAction;

--- a/ios/RNWhisperContext.h
+++ b/ios/RNWhisperContext.h
@@ -36,16 +36,19 @@ typedef struct {
 } RNWhisperContextRecordState;
 
 @interface RNWhisperContext : NSObject {
+    int contextId;
+    dispatch_queue_t dQueue;
     struct whisper_context * ctx;
     RNWhisperContextRecordState recordState;
 }
 
-+ (instancetype)initWithModelPath:(NSString *)modelPath;
++ (instancetype)initWithModelPath:(NSString *)modelPath contextId:(int)contextId;
 - (struct whisper_context *)getContext;
+- (dispatch_queue_t)getDispatchQueue;
 - (OSStatus)transcribeRealtime:(int)jobId
     options:(NSDictionary *)options
     onTranscribe:(void (^)(int, NSString *, NSDictionary *))onTranscribe;
-- (int)transcribeFile:(int)jobId
+- (void)transcribeFile:(int)jobId
     audioData:(float *)audioData
     audioDataCount:(int)audioDataCount
     options:(NSDictionary *)options

--- a/ios/RNWhisperContext.h
+++ b/ios/RNWhisperContext.h
@@ -49,7 +49,8 @@ typedef struct {
     audioData:(float *)audioData
     audioDataCount:(int)audioDataCount
     options:(NSDictionary *)options
-    onProgress:(void (^)(int))onProgress;
+    onProgress:(void (^)(int))onProgress
+    onEnd:(void (^)(int))onEnd;
 - (void)stopTranscribe:(int)jobId;
 - (bool)isCapturing;
 - (bool)isTranscribing;

--- a/ios/RNWhisperContext.mm
+++ b/ios/RNWhisperContext.mm
@@ -268,14 +268,17 @@ void AudioInputCallback(void * inUserData,
     audioDataCount:(int)audioDataCount
     options:(NSDictionary *)options
     onProgress:(void (^)(int))onProgress
+    onEnd:(void (^)(int))onEnd
 {
-    self->recordState.isStoppedByAction = false;
-    self->recordState.isTranscribing = true;
-    self->recordState.jobId = jobId;
-    int code = [self fullTranscribeWithProgress:onProgress jobId:jobId audioData:audioData audioDataCount:audioDataCount options:options];
-    self->recordState.jobId = -1;
-    self->recordState.isTranscribing = false;
-    return code;
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        self->recordState.isStoppedByAction = false;
+        self->recordState.isTranscribing = true;
+        self->recordState.jobId = jobId;
+        int code = [self fullTranscribeWithProgress:onProgress jobId:jobId audioData:audioData audioDataCount:audioDataCount options:options];
+        self->recordState.jobId = -1;
+        self->recordState.isTranscribing = false;
+        onEnd(code);
+    });
 }
 
 - (void)stopAudio {

--- a/ios/RNWhisperContext.mm
+++ b/ios/RNWhisperContext.mm
@@ -305,6 +305,7 @@ void AudioInputCallback(void * inUserData,
     }
     self->recordState.isCapturing = false;
     self->recordState.isStoppedByAction = true;
+    dispatch_barrier_sync(dQueue, ^{});
 }
 
 - (void)stopCurrentTranscribe {

--- a/ios/RNWhisperContext.mm
+++ b/ios/RNWhisperContext.mm
@@ -4,14 +4,23 @@
 
 @implementation RNWhisperContext
 
-+ (instancetype)initWithModelPath:(NSString *)modelPath {
++ (instancetype)initWithModelPath:(NSString *)modelPath contextId:(int)contextId {
     RNWhisperContext *context = [[RNWhisperContext alloc] init];
+    context->contextId = contextId;
     context->ctx = whisper_init_from_file([modelPath UTF8String]);
+    context->dQueue = dispatch_queue_create(
+        [[NSString stringWithFormat:@"RNWhisperContext-%d", contextId] UTF8String],
+        DISPATCH_QUEUE_SERIAL
+    );
     return context;
 }
 
 - (struct whisper_context *)getContext {
     return self->ctx;
+}
+
+- (dispatch_queue_t)getDispatchQueue {
+    return self->dQueue;
 }
 
 - (void)prepareRealtime:(NSDictionary *)options {
@@ -109,7 +118,7 @@ void AudioInputCallback(void * inUserData,
             nSamples != state->nSamplesTranscribing
         ) {
             state->isTranscribing = true;
-            dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+            dispatch_async([state->mSelf getDispatchQueue], ^{
                 [state->mSelf fullTranscribeSamples:state];
             });
         }
@@ -140,7 +149,7 @@ void AudioInputCallback(void * inUserData,
 
     if (!state->isTranscribing) {
         state->isTranscribing = true;
-        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        dispatch_async([state->mSelf getDispatchQueue], ^{
             [state->mSelf fullTranscribeSamples:state];
         });
     }
@@ -263,14 +272,14 @@ void AudioInputCallback(void * inUserData,
     return status;
 }
 
-- (int)transcribeFile:(int)jobId
+- (void)transcribeFile:(int)jobId
     audioData:(float *)audioData
     audioDataCount:(int)audioDataCount
     options:(NSDictionary *)options
     onProgress:(void (^)(int))onProgress
     onEnd:(void (^)(int))onEnd
 {
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+    dispatch_async(dQueue, ^{
         self->recordState.isStoppedByAction = false;
         self->recordState.isTranscribing = true;
         self->recordState.jobId = jobId;


### PR DESCRIPTION
Fix #107.

Currently we used `encoder_begin_callback` for the abort method, but it does not directly terminate the thread. This PR change the context uses an own dispatch_queue_t & wait it finished on stop method or release.

It probably have the same issue on Android, I'll investigating for it later.

- ~~[ ] Release queue on invalidating~~