### PR TITLE
feat: implement VAD on realtime transcription

### DIFF
--- a/android/src/main/java/com/rnwhisper/WhisperContext.java
+++ b/android/src/main/java/com/rnwhisper/WhisperContext.java
@@ -162,6 +162,27 @@ public class WhisperContext {
     }
   }
 
+  private boolean vad(ReadableMap options, short[] shortBuffer, int nSamples, int n) {
+    boolean isSpeech = true;
+    if (!isTranscribing && options.hasKey("useVad") && options.getBoolean("useVad")) {
+      int vadSec = options.hasKey("vadMs") ? options.getInt("vadMs") / 1000 : 2;
+      int sampleSize = vadSec * SAMPLE_RATE;
+      if (nSamples + n > sampleSize) {
+        int start = nSamples + n - sampleSize;
+        float[] audioData = new float[sampleSize];
+        for (int i = 0; i < sampleSize; i++) {
+          audioData[i] = shortBuffer[i + start] / 32768.0f;
+        }
+        float vadThold = options.hasKey("vadThold") ? (float) options.getDouble("vadThold") : 0.6f;
+        float vadFreqThold = options.hasKey("vadFreqThold") ? (float) options.getDouble("vadFreqThold") : 0.6f;
+        isSpeech = vadSimple(audioData, sampleSize, vadThold, vadFreqThold);
+      } else {
+        isSpeech = false;
+      }
+    }
+    return isSpeech;
+  }
+
   public int startRealtimeTranscribe(int jobId, ReadableMap options) {
     if (isCapturing || isTranscribing) {
       return -100;
@@ -223,6 +244,12 @@ public class WhisperContext {
                 ) {
                   emitTranscribeEvent("@RNWhisper_onRealtimeTranscribeEnd", Arguments.createMap());
                 } else if (!isTranscribing) {
+                  short[] shortBuffer = shortBufferSlices.get(sliceIndex);
+                  boolean isSpeech = vad(options, shortBuffer, nSamples, 0);
+                  if (!isSpeech) {
+                    emitTranscribeEvent("@RNWhisper_onRealtimeTranscribeEnd", Arguments.createMap());
+                    break;
+                  }
                   isTranscribing = true;
                   fullTranscribeSamples(options, true);
                 }
@@ -245,22 +272,7 @@ public class WhisperContext {
                 shortBuffer[nSamples + i] = buffer[i];
               }
 
-              boolean isSpeech = true;
-              if (!isTranscribing && options.hasKey("useVad") && options.getBoolean("useVad")) {
-                int vadSec = options.hasKey("vadMs") ? options.getInt("vadMs") / 1000 : 2;
-                int sampleSize = vadSec * SAMPLE_RATE;
-                if (nSamples + n > sampleSize) {
-                  float vadThold = options.hasKey("vadThold") ? (float) options.getDouble("vadThold") : 0.6f;
-                  float vadFreqThold = options.hasKey("vadFreqThold") ? (float) options.getDouble("vadFreqThold") : 0.6f;
-                  float[] audioData = new float[sampleSize];
-                  for (int i = 0; i < sampleSize; i++) {
-                    audioData[i] = shortBuffer[nSamples + i] / 32768.0f;
-                  }
-                  isSpeech = vadSample(audioData, sampleSize, vadThold, vadFreqThold);
-                } else {
-                  isSpeech = false;
-                }
-              }
+              boolean isSpeech = vad(options, shortBuffer, nSamples, n);
 
               nSamples += n;
               sliceNSamples.set(sliceIndex, nSamples);
@@ -613,7 +625,7 @@ public class WhisperContext {
   protected static native long initContext(String modelPath);
   protected static native long initContextWithAsset(AssetManager assetManager, String modelPath);
   protected static native long initContextWithInputStream(PushbackInputStream inputStream);
-  protected static native boolean vadSample(float[] audio_data, int audio_data_len, float vad_thold, float vad_freq_thold);
+  protected static native boolean vadSimple(float[] audio_data, int audio_data_len, float vad_thold, float vad_freq_thold);
   protected static native int fullTranscribe(
     int job_id,
     long context,

--- a/cpp/rn-whisper.cpp
+++ b/cpp/rn-whisper.cpp
@@ -57,7 +57,6 @@ bool rn_whisper_vad_simple(std::vector<float> & pcmf32, int sample_rate, int las
 
   if (n_samples_last >= n_samples) {
     // not enough samples - assume no speech
-    printf("not enough samples - assume no speech\n");
     return false;
   }
 

--- a/cpp/rn-whisper.cpp
+++ b/cpp/rn-whisper.cpp
@@ -38,4 +38,56 @@ void rn_whisper_abort_all_transcribe() {
   }
 }
 
+void high_pass_filter(std::vector<float> & data, float cutoff, float sample_rate) {
+    const float rc = 1.0f / (2.0f * M_PI * cutoff);
+    const float dt = 1.0f / sample_rate;
+    const float alpha = dt / (rc + dt);
+
+    float y = data[0];
+
+    for (size_t i = 1; i < data.size(); i++) {
+        y = alpha * (y + data[i] - data[i - 1]);
+        data[i] = y;
+    }
+}
+
+bool rn_whisper_vad_simple(std::vector<float> & pcmf32, int sample_rate, int last_ms, float vad_thold, float freq_thold, bool verbose) {
+  const int n_samples      = pcmf32.size();
+  const int n_samples_last = (sample_rate * last_ms) / 1000;
+
+  if (n_samples_last >= n_samples) {
+    // not enough samples - assume no speech
+    printf("not enough samples - assume no speech\n");
+    return false;
+  }
+
+  if (freq_thold > 0.0f) {
+    high_pass_filter(pcmf32, freq_thold, sample_rate);
+  }
+
+  float energy_all  = 0.0f;
+  float energy_last = 0.0f;
+
+  for (int i = 0; i < n_samples; i++) {
+    energy_all += fabsf(pcmf32[i]);
+
+    if (i >= n_samples - n_samples_last) {
+      energy_last += fabsf(pcmf32[i]);
+    }
+  }
+
+  energy_all  /= n_samples;
+  energy_last /= n_samples_last;
+
+  if (verbose) {
+    fprintf(stderr, "%s: energy_all: %f, energy_last: %f, vad_thold: %f, freq_thold: %f\n", __func__, energy_all, energy_last, vad_thold, freq_thold);
+  }
+
+  if (energy_last > vad_thold*energy_all) {
+    return false;
+  }
+
+  return true;
+}
+
 }

--- a/cpp/rn-whisper.h
+++ b/cpp/rn-whisper.h
@@ -10,6 +10,7 @@ void rn_whisper_remove_abort_map(int job_id);
 void rn_whisper_abort_transcribe(int job_id);
 bool rn_whisper_transcribe_is_aborted(int job_id);
 void rn_whisper_abort_all_transcribe();
+bool rn_whisper_vad_simple(std::vector<float> & pcmf32, int sample_rate, int last_ms, float vad_thold, float freq_thold, bool verbose);
 
 #ifdef __cplusplus
 }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -750,16 +750,16 @@ PODS:
     - React-perflogger (= 0.71.11)
   - RNFS (2.20.0):
     - React-Core
-  - RNZipArchive (6.0.9):
+  - RNZipArchive (6.1.0):
     - React-Core
-    - RNZipArchive/Core (= 6.0.9)
+    - RNZipArchive/Core (= 6.1.0)
     - SSZipArchive (~> 2.2)
-  - RNZipArchive/Core (6.0.9):
+  - RNZipArchive/Core (6.1.0):
     - React-Core
     - SSZipArchive (~> 2.2)
   - SocketRocket (0.6.0)
   - SSZipArchive (2.4.3)
-  - whisper-rn (0.3.5):
+  - whisper-rn (0.3.6):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
@@ -994,10 +994,10 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: 4817d63dbc9d658f8dc0ec56bd9b83ce531129f0
   ReactCommon: 08723d2ed328c5cbcb0de168f231bc7bae7f8aa1
   RNFS: 4ac0f0ea233904cb798630b3c077808c06931688
-  RNZipArchive: 68a0c6db4b1c103f846f1559622050df254a3ade
+  RNZipArchive: ef9451b849c45a29509bf44e65b788829ab07801
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
   SSZipArchive: fe6a26b2a54d5a0890f2567b5cc6de5caa600aef
-  whisper-rn: 6f293154b175fee138a994fa00d0f414fb1f44e9
+  whisper-rn: e80c0482f6a632faafd601f98f10da0255c1e1ec
   Yoga: f7decafdc5e8c125e6fa0da38a687e35238420fa
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -267,7 +267,7 @@ export default function App() {
                     // Slice audio into 25 (or < 30) sec chunks for better performance
                     realtimeAudioSliceSec: 25,
                     // Voice Activity Detection - Start transcribing when speech is detected
-                    useVad: true,
+                    // useVad: true,
                   })
                 setStopTranscribe({ stop })
                 subscribe((evt) => {

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -266,7 +266,7 @@ export default function App() {
                     realtimeAudioSec: 60,
                     // Slice audio into 25 (or < 30) sec chunks for better performance
                     realtimeAudioSliceSec: 25,
-                    // 
+                    // Voice Activity Detection - Start transcribing when speech is detected
                     useVad: true,
                   })
                 setStopTranscribe({ stop })

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -266,6 +266,8 @@ export default function App() {
                     realtimeAudioSec: 60,
                     // Slice audio into 25 (or < 30) sec chunks for better performance
                     realtimeAudioSliceSec: 25,
+                    // 
+                    useVad: true,
                   })
                 setStopTranscribe({ stop })
                 subscribe((evt) => {

--- a/ios/RNWhisperContext.mm
+++ b/ios/RNWhisperContext.mm
@@ -78,6 +78,29 @@
     }
 }
 
+bool vad(RNWhisperContextRecordState *state, int16_t* audioBufferI16, int nSamples, int n)
+{
+    bool isSpeech = true;
+    if (!state->isTranscribing && state->options[@"useVad"]) {
+        int vadSec = state->options[@"vadMs"] != nil ? [state->options[@"vadMs"] intValue] / 1000 : 2;
+        int sampleSize = vadSec * WHISPER_SAMPLE_RATE;
+        if (nSamples + n > sampleSize) {
+            int start = nSamples + n - sampleSize;
+            std::vector<float> audioBufferF32Vec(sampleSize);
+            for (int i = 0; i < sampleSize; i++) {
+                audioBufferF32Vec[i] = (float)audioBufferI16[i + start] / 32768.0f;
+            }
+            float vadThold = state->options[@"vadThold"] != nil ? [state->options[@"vadThold"] floatValue] : 0.6f;
+            float vadFreqThold = state->options[@"vadFreqThold"] != nil ? [state->options[@"vadFreqThold"] floatValue] : 100.0f;
+            isSpeech = rn_whisper_vad_simple(audioBufferF32Vec, WHISPER_SAMPLE_RATE, 1000, vadThold, vadFreqThold, false);
+            NSLog(@"[RNWhisper] VAD result: %d", isSpeech);
+        } else {
+            isSpeech = false;
+        }
+    }
+    return isSpeech;
+}
+
 void AudioInputCallback(void * inUserData,
     AudioQueueRef inAQ,
     AudioQueueBufferRef inBuffer,
@@ -118,6 +141,11 @@ void AudioInputCallback(void * inUserData,
             !state->isTranscribing &&
             nSamples != state->nSamplesTranscribing
         ) {
+            int16_t* audioBufferI16 = (int16_t*) [state->shortBufferSlices[state->sliceIndex] pointerValue];
+            if (!vad(state, audioBufferI16, nSamples, 0)) {
+                state->transcribeHandler(state->jobId, @"end", @{});
+                return;
+            }
             state->isTranscribing = true;
             dispatch_async([state->mSelf getDispatchQueue], ^{
                 [state->mSelf fullTranscribeSamples:state];
@@ -144,24 +172,7 @@ void AudioInputCallback(void * inUserData,
         audioBufferI16[nSamples + i] = ((short*)inBuffer->mAudioData)[i];
     }
 
-    bool isSpeech = true;
-    if (!state->isTranscribing && state->options[@"useVad"]) {
-        int vadSec = state->options[@"vadMs"] != nil ? [state->options[@"vadMs"] intValue] / 1000 : 2;
-        int sampleSize = vadSec * WHISPER_SAMPLE_RATE;
-        if (nSamples + n > sampleSize) {
-            int start = nSamples + n - sampleSize;
-            std::vector<float> audioBufferF32Vec(sampleSize);
-            for (int i = 0; i < sampleSize; i++) {
-                audioBufferF32Vec[i] = (float)audioBufferI16[i + start] / 32768.0f;
-            }
-            float vadThold = state->options[@"vadThold"] != nil ? [state->options[@"vadThold"] floatValue] : 0.6f;
-            float vadFreqThold = state->options[@"vadFreqThold"] != nil ? [state->options[@"vadFreqThold"] floatValue] : 100.0f;
-            isSpeech = rn_whisper_vad_simple(audioBufferF32Vec, WHISPER_SAMPLE_RATE, 1000, vadThold, vadFreqThold, false);
-            NSLog(@"[RNWhisper] VAD result: %d", isSpeech);
-        } else {
-            isSpeech = false;
-        }
-    }
+    bool isSpeech = vad(state, audioBufferI16, nSamples, n);
     nSamples += n;
     state->sliceNSamples[state->sliceIndex] = [NSNumber numberWithInt:nSamples];
 

--- a/ios/RNWhisperContext.mm
+++ b/ios/RNWhisperContext.mm
@@ -145,7 +145,7 @@ void AudioInputCallback(void * inUserData,
     }
 
     bool isSpeech = true;
-    if (state->options[@"useVad"]) {
+    if (!state->isTranscribing && state->options[@"useVad"]) {
         if (nSamples + n > WHISPER_SAMPLE_RATE * 2) {
             int start = nSamples + n - WHISPER_SAMPLE_RATE * 2;
             std::vector<float> audioBufferF32Vec(WHISPER_SAMPLE_RATE * 2);

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,12 @@ export type TranscribeRealtimeOptions = TranscribeOptions & {
    * (Default: Equal to `realtimeMaxAudioSec`)
    */
   realtimeAudioSliceSec?: number
+  /**
+   * Start transcribe on recording when the audio volume is greater than the threshold by using VAD (Voice Activity Detection).
+   * The first VAD will be triggered after 2 second of recording.
+   * (Default: false)
+   */
+  useVad?: boolean
 }
 
 export type TranscribeRealtimeEvent = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,6 +64,18 @@ export type TranscribeRealtimeOptions = TranscribeOptions & {
    * (Default: false)
    */
   useVad?: boolean
+  /**
+   * The length of the collected audio is used for VAD. (ms) (Default: 2000)
+   */
+  vadMs?: number
+  /**
+   * VAD threshold. (Default: 0.6)
+   */
+  vadThold?: number
+  /**
+   * Frequency to apply High-pass filter in VAD. (Default: 100.0)
+   */
+  vadFreqThold?: number
 }
 
 export type TranscribeRealtimeEvent = {


### PR DESCRIPTION
Add simple VAD as options to start transcription on recording, it will greatly reduce the waste of resources. It also help #89.

The current VAD implementation is take from [whisper.cpp/examples/common.cpp](https://github.com/ggerganov/whisper.cpp/blob/903c9579b86658798035cc9a3e358b355eb72a43/examples/common.cpp#L706), we could use another library instead like [libfvad](https://github.com/dpirch/libfvad) If we find it has more benefits.

TODO:
- [x] Option: vadThold, vadFreqThold
- [x] Android
- [x] Use VAD to check last transcription