### PR TITLE
fix: 0.76 version of react native for ios

### DIFF
--- a/whisper-rn.podspec
+++ b/whisper-rn.podspec
@@ -47,20 +47,7 @@ Pod::Spec.new do |s|
 
   # Don't install the dependencies when we run `pod install` in the old architecture.
   if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
-    s.compiler_flags = base_compiler_flags + " " + folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
-    new_arch_cpp_flags = "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1"
-    s.pod_target_xcconfig = {
-      "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
-      "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
-      "OTHER_LDFLAGS" => base_ld_flags,
-      "OTHER_CFLAGS" => base_optimizer_flags,
-      "OTHER_CPLUSPLUSFLAGS" => new_arch_cpp_flags + " " + base_optimizer_flags
-    }
-    s.dependency "React-Codegen"
-    s.dependency "RCT-Folly"
-    s.dependency "RCTRequired"
-    s.dependency "RCTTypeSafety"
-    s.dependency "ReactCommon/turbomodule/core"
+    install_modules_dependencies(s)
   end
 
   s.subspec "no-require-arc" do |ss|


### PR DESCRIPTION
Default to using react native provided installer for RCT_NEW_ARCH_ENABLED.