### PR TITLE
fix: broken export paths in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,16 @@
   "source": "src/index",
   "exports": {
     "./*": {
-      "import": "./lib/module/*",
-      "require": "./lib/commonjs/*",
-      "types": "./lib/typescript/*",
-      "react-native": "src/*"
+      "react-native": "./src/*.ts",
+      "types": "./lib/typescript/*.d.ts",
+      "import": "./lib/module/*.js",
+      "require": "./lib/commonjs/*.js"
+    },
+    "./*/": {
+      "react-native": "./src/*/index.ts",
+      "types": "./lib/typescript/*/index.d.ts",
+      "import": "./lib/module/*/index.js",
+      "require": "./lib/commonjs/*/index.js"
     }
   },
   "files": [


### PR DESCRIPTION
## Problem

Subpath imports like `whisper.rn/realtime-transcription` and `whisper.rn/realtime-transcription/adapters/AudioPcmStreamAdapter` fail to resolve under Metro. I was seeing this error at run time:

`Error: Cannot find module 'whisper.rn/realtime-transcription/adapters/AudioPcmStreamAdapter'`

And this warning:

```
WARN  The package node_modules/whisper.rn contains an invalid package.json configuration.
Reason: The resolution for ".../realtime-transcription/adapters/AudioPcmStreamAdapter" defined in
"exports" is .../lib/module/realtime-transcription/adapters/AudioPcmStreamAdapter, however this file
does not exist. Falling back to file-based resolution.
```

## Root Cause

in `package.json`'s `exports` field:

1. **`"react-native": "src/*"` is missing the leading `./`.** Per the package-exports spec, subpath export targets must start with `./`. Metro (and Node) reject this target as invalid and discard the condition entirely.

2. **None of the wildcard targets include a file extension.** Metro's `exports`-map resolution requires an exact file match. So a subpath like `realtime-transcription/adapters/AudioPcmStreamAdapter` that doesn't point to a file cannot be resolved.

Once exact-match resolution via `exports` fails, Metro falls back to legacy file-based resolution — but that *also* fails, because `realtime-transcription/` only exists under `src/`, `lib/module/`, and `lib/commonjs/`, never at the package root. So every resolution path for this subpath dead-ends.

## Note about the example app

The example app in the repo points to the local files (`../src`). So it wouldn't show this issue. If you add `whisper.rn` as a package, you will see this issue.

## Environment

- `whisper.rn`: 0.6.0 (latest at time of report)
- `react-native`: 0.86.0
- `metro`: 0.84.4
- `@react-native/metro-config`: 0.84.4
